### PR TITLE
Don’t disable/enable patches which are already in their desired state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ patch_disable_keyboard:
 # $2 is the new patch name
 define patch_mv
 	for i in *.img.d; do \
-	 mv $$i/$1 $$i/$2; \
+	 if [ -e $$i/$1 ]; then mv $$i/$1 $$i/$2; else true "Nothing to do for $$i/$2."; fi; \
 	done
 endef
 


### PR DESCRIPTION
Avoids `mv` fail and in turn `make` fail.

```
for i in *.img.d; do mv $i/006_battery_validate.patch $i/006_battery_validate.patch.OFF; done
mv: cannot stat 't430.G1HT35WW.img.d/006_battery_validate.patch': No such file or directory
mv: cannot stat 't430s.G7HT39WW.img.d/006_battery_validate.patch': No such file or directory
mv: cannot stat 't530.G4HT39WW.img.d/006_battery_validate.patch': No such file or directory
mv: cannot stat 'w530.G4HT39WW.img.d/006_battery_validate.patch': No such file or directory
mv: cannot stat 'x230.G2HT35WW.img.d/006_battery_validate.patch': No such file or directory
mv: cannot stat 'x230t.GCHT25WW.img.d/006_battery_validate.patch': No such file or directory
Makefile:126: recipe for target 'patch_disable_battery' failed
make: *** [patch_disable_battery] Error 1
```