### PR TITLE
Fix x220 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,19 +303,21 @@ endef
 #   rule definitions
 
 # Hacky, non generic rules
-$(call rule_fl2,t430.G1HT35WW.img.enc,t430.G1HT35WW.s01D2000.FL2)
 $(call rule_fl2,t430.G1HT34WW.img.enc,t430.G1HT34WW.s01D2000.FL2)
+$(call rule_fl2,t430.G1HT35WW.img.enc,t430.G1HT35WW.s01D2000.FL2)
 $(call rule_fl2,t430s.G7HT39WW.img.enc,t430s.G7HT39WW.s01D8000.FL2)
 $(call rule_fl2,t530.G4HT39WW.img.enc,t530.G4HT39WW.s01D5100.FL2)
 $(call rule_fl2,w530.G4HT39WW.img.enc,w530.G4HT39WW.s01D5200.FL2)
+$(call rule_fl2,x220.8DHT34WW.img.enc,x220.8DHT34WW.s01CB000.FL2)
 $(call rule_fl2,x230.G2HT35WW.img.enc,x230.G2HT35WW.s01D3000.FL2)
 $(call rule_fl2,x230t.GCHT25WW.img.enc,x230t.GCHT25WW.s01DA000.FL2)
 
-$(call rule_iso,t430.G1HT35WW.s01D2000.FL2,g1uj40us.iso)
 $(call rule_iso,t430.G1HT34WW.s01D2000.FL2,g1uj25us.iso)
-$(call rule_iso,x230.G2HT35WW.s01D3000.FL2,g2uj25us.iso)
+$(call rule_iso,t430.G1HT35WW.s01D2000.FL2,g1uj40us.iso)
+$(call rule_iso,t430s.G7HT39WW.s01D8000.FL2,g7uj19us.iso)
 $(call rule_iso,t530.G4HT39WW.s01D5100.FL2,g4uj30us.iso)
 $(call rule_iso,w530.G4HT39WW.s01D5200.FL2,g5uj28us.iso)
-$(call rule_iso,t430s.G7HT39WW.s01D8000.FL2,g7uj19us.iso)
+$(call rule_iso,x220.8DHT34WW.s01CB000.FL2,8duj27us.iso)
+$(call rule_iso,x230.G2HT35WW.s01D3000.FL2,g2uj25us.iso)
 $(call rule_iso,x230t.GCHT25WW.s01DA000.FL2,gcuj24us.iso)
 

--- a/descriptions.txt
+++ b/descriptions.txt
@@ -52,7 +52,7 @@ t430.G1HT35WW.img.orig     08ab64a0e61865781466fb2bfd97210fe0651bc8 t430 EC 1.13
 t430s.G7HT39WW.img.orig    6e68545a76b42d534c8a4b24a63bf7bece996522 t430s EC 1.15 (decrypted)
 t530.G4HT39WW.img.orig     85257101482d8ec7a70d860e176a5fff805fd572 t530 EC 1.13 (decrypted)
 w530.G4HT39WW.img.orig     85257101482d8ec7a70d860e176a5fff805fd572 w530 EC 1.13 (decrypted)
-x220.8DHT34WW.img.enc.orig 5dccc0284991ef5144e2b9a114249edb77fa0b28 x220 EC 1.24 (encrypted)
+x220.8DHT34WW.img.orig     ccdff63b5a14dda714e2a1ca14803f15ee0befde x220 EC 1.24 (encrypted)
 x230.G2HT35WW.img.orig     d70f5434ef316a66a6195651d9e231e84a2464a1 x230 EC 1.14 (decrypted)
 x230t.GCHT25WW.img.orig    d9db308756a6a82ff83ee8e3eae930b5ff550e28 x230t EC 1.14 (decrypted)
 x250.N10HT17W.img.enc.orig FIXME                                    x250 EC 1.16 (encrypted)


### PR DESCRIPTION
# Do not merge yet. This PR is wrong.

Makefile expects checksum over the decrypted EC firmware image and not the (partly) encrypted one. I ensured that the checksum over the (partly) encrypted image matched before decrypting it and adding the checksum over it.

* Add hacky, non generic rule for the x220
* Sort hacky, non generic rules