### PR TITLE
Use /usr/bin/env where appropriate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all:    list_laptops
 
 .PHONY: all
 
-SHELL = /bin/bash
+SHELL = /usr/bin/env bash
 
 QEMU_OPTIONS ?= -enable-kvm
 

--- a/scripts/checksum
+++ b/scripts/checksum
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Look up the given filename in the description file and confirm that
 # the checksum matches

--- a/scripts/geteltorito
+++ b/scripts/geteltorito
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use Getopt::Std;
 

--- a/scripts/xx30.encrypt
+++ b/scripts/xx30.encrypt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Quick and dirty encryptor
 # Copyright (C) 2016 Hamish Coleman


### PR DESCRIPTION
Some Linux systems (GuixSD, NixOS) do not install programs like Bash and Perl to /usr/bin, and /usr/bin/env has to be used to locate these instead.