### PR TITLE
Add openssl-devel dependency for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ warning message.
    On Fedora, you could install it with dnf:
 
     ```
-    sudo dnf install git mtools
+    sudo dnf install git mtools openssl-devel
     sudo dnf group install "C Development Tools and Libraries"
     ```
     


### PR DESCRIPTION
Without the `openssl-devel` package, the following error message comes up:
```
git submodule update
make -C mec-tools
make[1]: Entering directory '/tmp/thinkpad-ec/mec-tools'
cc -Wall -O2 mec_encrypt.c -o mec_encrypt -lcrypto
make[1]: Leaving directory '/tmp/thinkpad-ec/mec-tools'
mec_encrypt.c:6:10: fatal error: openssl/blowfish.h: No such file or directory
    6 | #include <openssl/blowfish.h>
      |          ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[1]: *** [Makefile:8: mec_encrypt] Error 1
make: *** [Makefile:294: mec-tools/mec_encrypt] Error 2
```