### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ warning message.
    ```
    sudo dd if=patched.x230.img of=/dev/sdx bs=4M status=progress conv=fsync
    ```
+   
+   Properly unmount the USB stick.
 
 Your USB stick is now ready to boot and install the patched firmware.
 


### PR DESCRIPTION
Reminder to properly unmount the USB stick.
Filing to do so, might, in certain cases, cause errors further down the road.


**Rationale:**
I spent more than I want to admit attempting to flash the BIOS, with error being caused by not unmounting the USB stick properly. Flashing was failing with "ERROR 081 - Failed to load BIOS image file! Status = 103". Redoing steps 1 through 9, followed by a unmount helped.

Note: another success story:
- T530
- Enabling unauthorized batteries
- BIOS: G4ETB4WW (2.74) with EC G4HT39WW (1.13)
- BIOS-stick prepared with bootable Ubuntu-stick