### PR TITLE
Added note about caps lock led

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ disabled by default) to disable the authentic battery validation check.
 
 With the patches included here, you can install the classic keyboard
 hardware on many xx30 series laptops and make almost every key work properly.
-The only keys that are not working are Fn+F3 (Battery) and Fn+F12 (Hibernate)
+The only keys that are not working are Fn+F3 (Battery) and Fn+F12 (Hibernate), and on some devices the Caps Lock LED (Caps Lock Indicator Light).
 
 Unfortunately, there are a small number of thinkpads with a model number
 from the "xx30" series that are using a completely different EC CPU and


### PR DESCRIPTION
Caps lock led is broken, confirmed on a T430, also there is an issue open with other users who have encountered the same issue.