### PR TITLE
add link to documentation for dumping/programming EC over JTAG

### DIFF
--- a/docs/chips.txt
+++ b/docs/chips.txt
@@ -40,6 +40,7 @@ ThinkPad xx30 series:
     write the firmware with an external programmer, which might help in
     the case of a bricked system.
     (see discussion: http://notebook1.ru/forma1/viewtopic.php?f=70&t=109179)
+    The procedure for doing this is documented here: https://github.com/taglour/x230-ec-jtag
 
 ThinkPad l430:
 --------------


### PR DESCRIPTION
Reading/writing the EC over JTAG is not documented anywhere, but it keeps coming up:
https://github.com/hamishcoleman/thinkpad-ec/issues/181
https://github.com/hamishcoleman/thinkpad-ec/issues/173#issuecomment-636091113
https://github.com/hamishcoleman/thinkpad-ec/issues/91#issuecomment-619283229
https://github.com/hamishcoleman/thinkpad-ec/issues/57
https://github.com/hamishcoleman/thinkpad-ec/issues/1#issuecomment-215401705

Documented the procedure for doing this, and added a link to this documentation in the `thinkpad-ec` docs.