### PR TITLE
Add NixOS Support with integrated IDE

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,53 @@
+# EditorConfig configuration for this repository -- https://EditorConfig.org
+
+# Top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file, utf-8 charset
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+# Ignore diffs/patches
+[*.{diff,patch}]
+end_of_line = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset
+
+# Prefer space-indent for..
+[*.{json,lock,md,pl,pm,py,rb,xml}]
+indent_style = space
+
+# Prefer tab-indent for..
+[*.{nix,sh,bash}]
+indent_style = tab
+
+[*.{json,lock,md,nix,rb,sh}]
+indent_size = 2
+
+[*.lock]
+indent_size = unset
+
+[*.md]
+trim_trailing_whitespace = true
+
+# binaries
+[*.nib]
+end_of_line = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset
+charset = unset
+
+[eggs.nix]
+trim_trailing_whitespace = unset
+
+# You can add file-specific configuration using:
+#
+# [path/to/file]
+# end_of_line = unset
+# indent_style = unset
+# insert_final_newline = unset
+# trim_trailing_whitespace = unset
+# other config..

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+# shellcheck shell=sh # POSIX
+
+# This file is used to provide directory-oriented environment variables and integrations
+
+use flake

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+*.nix @kreyren
+/tasks/ @kreyren
+.direnv @kreyren
+default.code-workspace @kreyren

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ nuvoton-tools/
 
 # Temp are (should be) just junk
 *.tmp
+.direnv/

--- a/default.code-workspace
+++ b/default.code-workspace
@@ -1,0 +1,128 @@
+{
+	"folders": [
+		{ "path": "." },
+	],
+
+	"settings": {
+		// Enable liguratures
+		"editor.fontLigatures": true,
+		"editor.fontFamily": "'Fira Code'",
+		"terminal.integrated.fontFamily": "'Fira Code'",
+
+		"editor.renderWhitespace": "all",
+		"terminal.integrated.scrollback": 20000,
+		"nix.enableLanguageServer": true,
+		"nix.serverPath": "nil",
+		"nix.serverSettings": {
+			// settings for 'nil' Language Server
+			"nil": {
+				"formatting": {
+					"command": ["nixpkgs-fmt"]
+				}
+			}
+		},
+		"bracket-pair-colorizer-2.excludedLanguages": [
+			"nix" // Does weird and confusing coloring, seems not compatible
+		],
+		"editor.wordWrap": "on", // Enforce word-wrapped coding style
+		"terminal.integrated.defaultProfile.linux": "bash", // Use bash by default
+		"terminal.integrated.env.linux": {
+			"EDITOR": "nano", // To open git things in codium
+		},
+
+		// Git
+		"git.autofetch": true,
+
+		// Code-eol
+		"code-eol.highlightExtraWhitespace": true,
+		"code-eol.newlineCharacter": "↵",
+		"code-eol.crlfCharacter": "↓",
+
+		// Task tree
+		"todo-tree.general.tags": [
+			"FIXME",
+			"TODO",
+			"DOCS",
+			"HACK",
+			"REVIEW",
+			"DNM", // Do Not Merge
+			"DNC", // Do Not Contribute
+			"DNR" // Do Not Release
+		],
+		// NOTE: Icons has to be valid octicon (https://primer.style/foundations/icons/)
+		"todo-tree.highlights.customHighlight": {
+			// FIXME(Krey): Test
+			"FIXME": {
+				"foreground": "#ff8000",
+				"icon": "tag",
+				"fontWeight": "bold"
+			},
+			// TODO(Krey): Test
+			"TODO": {
+				"foreground": "#00ffea",
+				"icon": "tasklist",
+				"fontWeight": "bold"
+			},
+			// DOCS(Krey): Test
+			"DOCS": {
+				"foreground": "#ffffff",
+				"background": "#2f00ff",
+				"icon": "repo",
+				"fontWeight": "bold"
+			},
+			// HACK(Krey): Test
+			"HACK": {
+				"foreground": "#ffffff",
+				"background": "#ff4d00",
+				"icon": "repo",
+				"fontWeight": "bold"
+			},
+			// REVIEW(Krey): Test
+			"REVIEW": {
+				"foreground": "#ffffff",
+				"background": "#b300ff",
+				"icon": "code-review",
+				"fontWeight": "bold"
+			},
+			// DNM(Krey): Test
+			"DNM": {
+				"background": "#ff0000",
+				"foreground": "#ffffff",
+				"icon": "shield-x",
+				"fontWeight": "bold"
+			},
+			// DNR(Krey): Test
+			"DNR": {
+				"background": "#ff0000",
+				"foreground": "#ffffff",
+				"icon": "shield-x",
+				"fontWeight": "bold"
+			},
+			// DNC(Krey): Test
+			"DNC": {
+				"background": "#fffb00",
+				"foreground": "#000000",
+				"icon": "shield-x",
+				"fontWeight": "bold"
+			}
+		},
+		"todo-tree.regex.regex": "($TAGS)((\\-.*|)\\(.*\\)):", // ($TAGS)((\\-.*|)\\(.*\\)):
+	},
+
+	"extensions": {
+		"recommendations": [
+			"jnoortheen.nix-ide",
+			"oderwat.indent-rainbow",
+			"arrterian.nix-env-selector",
+			"medo64.render-crlf",
+			"aaron-bond.better-comments",
+			"mkhl.direnv",
+			"coenraads.bracket-pair-colorizer-2",
+			"editorconfig.editorconfig",
+			"pkief.material-icon-theme",
+			"markwylde.vscode-filesize",
+			"plorefice.devicetree",
+			"timonwong.shellcheck"
+		]
+	}
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,158 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1722555600,
+        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-root": {
+      "locked": {
+        "lastModified": 1713493429,
+        "narHash": "sha256-ztz8JQkI08tjKnsTpfLqzWoKFQF4JGu2LRz8bkdnYUk=",
+        "owner": "srid",
+        "repo": "flake-root",
+        "rev": "bc748b93b86ee76e2032eecda33440ceb2532fcd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "flake-root",
+        "type": "github"
+      }
+    },
+    "mission-control": {
+      "locked": {
+        "lastModified": 1718815759,
+        "narHash": "sha256-hzLbxU580EaxKmkbQkiaMF3NoIzrcmVryGul5WSQatA=",
+        "owner": "Platonic-Systems",
+        "repo": "mission-control",
+        "rev": "db5e2cc39c6799b301412d69182b9221c65146a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Platonic-Systems",
+        "repo": "mission-control",
+        "type": "github"
+      }
+    },
+    "nixlib": {
+      "locked": {
+        "lastModified": 1722732880,
+        "narHash": "sha256-do2Mfm3T6SR7a5A804RhjQ+JTsF5hk4JTPGjCTRM/m8=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "8bebd4c74f368aacb047f0141db09ec6b339733c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixos-flake": {
+      "locked": {
+        "lastModified": 1721140942,
+        "narHash": "sha256-iEqZGdnkG+Hm0jZhS59NJwEyB6z9caVnudWPGHZ/FAE=",
+        "owner": "srid",
+        "repo": "nixos-flake",
+        "rev": "5734c1d9a5fe0bc8e8beaf389ad6227392ca0108",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "nixos-flake",
+        "type": "github"
+      }
+    },
+    "nixos-generators": {
+      "inputs": {
+        "nixlib": "nixlib",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1723078345,
+        "narHash": "sha256-HSxOQEKNZXiJe9aWnckTTCThOhcRCabwHa32IduDKLk=",
+        "owner": "nix-community",
+        "repo": "nixos-generators",
+        "rev": "d6c5d29f58acc10ea82afff1de2b28f038f572bd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixos-generators",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1722869614,
+        "narHash": "sha256-7ojM1KSk3mzutD7SkrdSflHXEujPvW1u7QuqWoTLXQU=",
+        "rev": "883180e6550c1723395a3a342f830bfc5c371f6b",
+        "revCount": 633812,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2405.633812%2Brev-883180e6550c1723395a3a342f830bfc5c371f6b/01912867-c4cd-766e-bc62-2cc7d1546d12/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/%2A.tar.gz"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1722555339,
+        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1722813957,
+        "narHash": "sha256-IAoYyYnED7P8zrBFMnmp7ydaJfwTnwcnqxUElC1I26Y=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "cb9a96f23c491c081b38eab96d22fa958043c9fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "flake-root": "flake-root",
+        "mission-control": "mission-control",
+        "nixos-flake": "nixos-flake",
+        "nixos-generators": "nixos-generators",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+{
+	description = "Thinkpad-EC";
+
+	inputs = {
+		# Release inputs
+			nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/*.tar.gz";
+			nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
+
+
+		# Principle inputs
+			nixos-flake.url = "github:srid/nixos-flake";
+			flake-parts.url = "github:hercules-ci/flake-parts";
+			mission-control.url = "github:Platonic-Systems/mission-control";
+
+			flake-root.url = "github:srid/flake-root";
+
+		nixos-generators = {
+			url = "github:nix-community/nixos-generators";
+			inputs.nixpkgs.follows = "nixpkgs";
+		};
+	};
+
+	outputs = inputs @ { self, ... }:
+		inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+			imports = [
+				./tasks # Include Tasks
+				inputs.flake-root.flakeModule
+				inputs.mission-control.flakeModule
+			];
+
+			# Set Supported Systems
+			systems = [
+				"x86_64-linux"
+				"aarch64-linux"
+				"riscv64-linux"
+				"armv7l-linux"
+			];
+
+			perSystem = { system, config, inputs', ... }: {
+				devShells.default = inputs.nixpkgs.legacyPackages.${system}.mkShell {
+					name = "thinkpad-ec-devshell";
+					nativeBuildInputs = [
+						inputs.nixpkgs.legacyPackages.${system}.bashInteractive # For terminal
+						inputs.nixpkgs.legacyPackages.${system}.nil # Needed for linting
+						inputs.nixpkgs.legacyPackages.${system}.nixpkgs-fmt # Nixpkgs formatter
+						inputs.nixpkgs.legacyPackages.${system}.git # Working with the codebase
+						inputs.nixpkgs.legacyPackages.${system}.nano # Editor to work with the codebase in cli
+
+						inputs.nixpkgs.legacyPackages.${system}.fira-code # For liquratures in code editors
+
+						inputs.nixpkgs.legacyPackages.${system}.flashrom
+
+						inputs.nixos-generators.packages.${system}.nixos-generate
+
+						inputs.nixpkgs.legacyPackages.${system}.openssl
+						inputs.nixpkgs.legacyPackages.${system}.wget
+					];
+					inputsFrom = [
+						config.mission-control.devShell
+						config.flake-root.devShell
+					];
+					# Environmental Variables
+					#VARIABLE = "value"; # Comment
+				};
+
+				formatter = inputs.nixpkgs.legacyPackages.${system}.nixpkgs-fmt;
+			};
+		};
+}

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -1,0 +1,1 @@
+Directory declaring internal tasks to use for managing the repository via Nix

--- a/tasks/default.nix
+++ b/tasks/default.nix
@@ -1,0 +1,6 @@
+{
+	imports = [
+		./editors
+		./tools
+	];
+}

--- a/tasks/editors/codium/default.nix
+++ b/tasks/editors/codium/default.nix
@@ -1,0 +1,13 @@
+{ ... }:
+
+{
+	perSystem = { inputs', lib, pkgs, ... }: {
+		mission-control.scripts = {
+			codium = {
+				description = "Open repository-standardized VSCodium version with configuration";
+				category = "Integrated Development Environments";
+				exec = "${inputs'.nixpkgs.legacyPackages.vscodium}/bin/codium \"$FLAKE_ROOT/default.code-workspace\"";
+			};
+		};
+	};
+}

--- a/tasks/editors/default.nix
+++ b/tasks/editors/default.nix
@@ -1,0 +1,3 @@
+{
+	imports = [ ./codium ];
+}

--- a/tasks/templates/hello/default.nix
+++ b/tasks/templates/hello/default.nix
@@ -1,0 +1,13 @@
+{ ... }:
+
+{
+	perSystem = { inputs', pkgs, lib, ... }: {
+		mission-control.scripts = {
+			hello = {
+				description = "Hello";
+				category = "Tests";
+				exec = "echo hello";
+			};
+		};
+	};
+}

--- a/tasks/tools/default.nix
+++ b/tasks/tools/default.nix
@@ -1,0 +1,5 @@
+{
+	imports = [
+		./direnv-reload
+	];
+}

--- a/tasks/tools/direnv-reload/default.nix
+++ b/tasks/tools/direnv-reload/default.nix
@@ -1,0 +1,25 @@
+{ ... }:
+
+# The BUILD Task
+
+{
+	perSystem = { pkgs, ... }: {
+		mission-control.scripts = {
+			"r" = {
+				description = "Reload the development environment";
+				category = "tools";
+
+				exec = pkgs.writeShellApplication {
+					name = "direnv-reload-build";
+
+					runtimeInputs = [
+						pkgs.direnv
+					];
+
+					# FIXME(Krey): This should use flake-root to set absolute path
+					text = builtins.readFile ./tasks-direnv-reload.sh;
+				};
+			};
+		};
+	};
+}

--- a/tasks/tools/direnv-reload/tasks-direnv-reload.sh
+++ b/tasks/tools/direnv-reload/tasks-direnv-reload.sh
@@ -1,0 +1,9 @@
+# shellcheck shell=sh # POSIX
+set +u # Do not fail on nounset as we use command-line arguments for logic
+
+direnv reload
+
+case "$?" in
+	0) : ;; # Success
+	*) echo "reload exitted with an unknown exit code: $?"
+esac


### PR DESCRIPTION
This contribution implement a support for building on NixOS by providing a `flake.nix` which is used to provide instructions to `nix` for processing (various functionality from building the repository to just getting a development shell with the dependencies).

It also includes a vscodium task (nix-only) which will upon using `, codium` deploy vscodium with cherry-picked extensions and configuration to get a standard development environment.

That way anyone who wants to view and work with the source code will get everything they need in a temporary shell without having to install any packages on their system if they use nix.

Fixes: https://github.com/hamishcoleman/thinkpad-ec/issues/258