### PR TITLE
Add Caps Lock LED support for 7 row keyboard on T430, T430s, W530, T530, X230, X230t

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ include .config
 
 PATCHES-$(CONFIG_KEYBOARD) += \
     001_keysym.patch 002_dead_keys.patch 003_keysym_replacements.patch \
-    004_fn_keys.patch 005_fn_key_swap.patch
+    004_fn_keys.patch 005_fn_key_swap.patch 008_capslock_led.patch
 
 PATCHES-$(CONFIG_BATTERY) += \
     006_battery_validate.patch

--- a/README.md
+++ b/README.md
@@ -36,10 +36,6 @@ With the patches included here, you can install the classic keyboard
 hardware on many xx30 series laptops and make almost every key work properly.
 The only keys that are not working are Fn+F3 (Battery) and Fn+F12 (Hibernate).
 
-The xx30 keyboards do not have a Caps Lock Indicator and the motherboard has
-no hardware support for a Caps Lock Indicator, so the replacement classic
-keyboard will never turn on the Indicator on any laptop.
-
 * A full writeup of the hardware modifications needed can be found at:
     http://www.thinkwiki.org/wiki/Install_Classic_Keyboard_on_xx30_Series_ThinkPads
 

--- a/t430.G1HT35WW.img.d/008_capslock_led.patch
+++ b/t430.G1HT35WW.img.d/008_capslock_led.patch
@@ -1,0 +1,27 @@
+Enable Caps Lock LED for T420 7-row classic keyboard on T430.
+
+The T420 keyboard has an LED in the Caps Lock key driven by keyboard
+connector pin 21. On the T430 motherboard, this pin is routed to EC
+ball D2 (GPIO163 / VCI_IN0#). The T420 keyboard has no backlight, so
+the backlight detect function of this pin is unused.
+
+This patch hooks the PS/2 SET LED (0xED) data byte handler via its
+jump table entry at 0x641B. When the host sends the LED state byte,
+the trampoline checks bit 2 (Caps Lock) and configures GPIO163 as a
+push-pull output driven LOW (LED ON, active-low) or HIGH (LED OFF),
+then continues to the original handler.
+
+GPIO163 shares its pin with VCI_IN0# (VBAT wake input), but on the T430
+this pin is used for keyboard backlight detection, which is unused with
+the T420 keyboard (no backlight). Switching from VCI_IN0# to GPIO mode
+has no practical side effect.
+
+Trampoline code is placed in free space at 0x23590.
+
+@@ capslock_led @@
+-00006410  f0 26 87 70 00 00 1c 64  20 20 c0 01 c4 64 00 00  |.&.p...d  ...d..|
++00006410  f0 26 87 70 00 00 1c 64  20 20 c0 01 1c 5c 00 00  |.&.p...d  ..`<..|
+-00023580  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
++00023580  0a 20 80 0f f0 00 cc c5  8a 21 09 00 51 26 80 90  |. .......!..Q&..|
+-00023590  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
++00023590  cf 21 21 04 00 18 60 00  20 20 80 0f 00 00 fc 66  |.!!...`.  .....f|

--- a/t430s.G7HT39WW.img.d/008_capslock_led.patch
+++ b/t430s.G7HT39WW.img.d/008_capslock_led.patch
@@ -1,0 +1,27 @@
+Enable Caps Lock LED for T420s 7-row classic keyboard on T430s.
+
+The T420s keyboard has an LED in the Caps Lock key driven by keyboard
+connector pin 21. On the T430s motherboard, this pin is routed to EC
+ball D2 (GPIO163 / VCI_IN0#). The T420s keyboard has no backlight, so
+the backlight detect function of this pin is unused.
+
+This patch hooks the PS/2 SET LED (0xED) data byte handler via its
+jump table entry at 0x610F. When the host sends the LED state byte,
+the trampoline checks bit 2 (Caps Lock) and configures GPIO163 as a
+push-pull output driven LOW (LED ON, active-low) or HIGH (LED OFF),
+then continues to the original handler.
+
+GPIO163 shares its pin with VCI_IN0# (VBAT wake input), but on the T430s
+this pin is used for keyboard backlight detection, which is unused with
+the T420s keyboard (no backlight). Switching from VCI_IN0# to GPIO mode
+has no practical side effect.
+
+Trampoline code is placed in free space at 0x24100.
+
+@@ capslock_led @@
+-0000610C  20 20 c0 01 b8 61 00 00  54 62 00 00 54 62 00 00  |  ...a..Tb..Tb..|
++0000610C  20 20 c0 01 24 e5 00 00  54 62 00 00 54 62 00 00  |  ..$...Tb..Tb..|
+-00024100  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
++00024100  0a 20 80 0f f0 00 cc c5  8a 21 09 00 51 26 80 90  |. .......!..Q&..|
+-00024110  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
++00024110  cf 21 21 04 00 18 60 00  20 20 80 0f 00 00 fc 66  |.!!...`.  .....f|

--- a/w530.G4HT39WW.img.d/008_capslock_led.patch
+++ b/w530.G4HT39WW.img.d/008_capslock_led.patch
@@ -1,0 +1,27 @@
+Enable Caps Lock LED for W520 7-row classic keyboard on W530.
+
+The W520 keyboard has an LED in the Caps Lock key driven by keyboard
+connector pin 21. On the W530 motherboard, this pin is routed to EC
+ball D2 (GPIO163 / VCI_IN0#). The W520 keyboard has no backlight, so
+the backlight detect function of this pin is unused.
+
+This patch hooks the PS/2 SET LED (0xED) data byte handler via its
+jump table entry at 0x6863. When the host sends the LED state byte,
+the trampoline checks bit 2 (Caps Lock) and configures GPIO163 as a
+push-pull output driven LOW (LED ON, active-low) or HIGH (LED OFF),
+then continues to the original handler.
+
+GPIO163 shares its pin with VCI_IN0# (VBAT wake input), but on the W530
+this pin is used for keyboard backlight detection, which is unused with
+the W520 keyboard (no backlight). Switching from VCI_IN0# to GPIO mode
+has no practical side effect.
+
+Trampoline code is placed in free space at 0x25260.
+
+@@ capslock_led @@
+-00006860  20 20 c0 01 0c 69 00 00  a8 69 00 00 a8 69 00 00  |  ...i...i...i..|
++00006860  20 20 c0 01 ac 62 00 00  a8 69 00 00 a8 69 00 00  |  ...b...i...i..|
+-00025260  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
++00025260  0a 20 80 0f f0 00 cc c5  8a 21 09 00 51 26 80 90  |. .......!..Q&..|
+-00025270  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
++00025270  cf 21 21 04 00 18 60 00  20 20 80 0f 00 00 fc 66  |.!!...`.  .....f|

--- a/x230.G2HT35WW.img.d/008_capslock_led.patch
+++ b/x230.G2HT35WW.img.d/008_capslock_led.patch
@@ -1,0 +1,27 @@
+Enable Caps Lock LED for X220 7-row classic keyboard on X230.
+
+The X220 keyboard has an LED in the Caps Lock key driven by keyboard
+connector pin 21. On the X230 motherboard, this pin is routed to EC
+ball D2 (GPIO163 / VCI_IN0#). The X220 keyboard has no backlight, so
+the backlight detect function of this pin is unused.
+
+This patch hooks the PS/2 SET LED (0xED) data byte handler via its
+jump table entry at 0x6654. When the host sends the LED state byte,
+the trampoline checks bit 2 (Caps Lock) and configures GPIO163 as a
+push-pull output driven LOW (LED ON, active-low) or HIGH (LED OFF),
+then continues to the original handler.
+
+GPIO163 shares its pin with VCI_IN0# (VBAT wake input), but on the X230
+this pin is used for keyboard backlight detection, which is unused with
+the X220 keyboard (no backlight). Switching from VCI_IN0# to GPIO mode
+has no practical side effect.
+
+Trampoline code is placed in free space at 0x23C60.
+
+@@ capslock_led @@
+-00006650  20 20 c0 01 fc 66 00 00  98 67 00 00 98 67 00 00  |  ...f...g...g..|
++00006650  20 20 c0 01 60 3c 02 00  98 67 00 00 98 67 00 00  |  ..`<...g...g..|
+-00023c60  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
++00023c60  0a 20 80 0f f0 00 cc c5  8a 21 09 00 51 26 80 90  |. .......!..Q&..|
+-00023c70  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
++00023c70  cf 21 21 04 00 18 60 00  20 20 80 0f 00 00 fc 66  |.!!...`.  .....f|

--- a/x230t.GCHT25WW.img.d/008_capslock_led.patch
+++ b/x230t.GCHT25WW.img.d/008_capslock_led.patch
@@ -1,0 +1,27 @@
+Enable Caps Lock LED for X220t 7-row classic keyboard on X230t.
+
+The X220t keyboard has an LED in the Caps Lock key driven by keyboard
+connector pin 21. On the X230 motherboard, this pin is routed to EC
+ball D2 (GPIO163 / VCI_IN0#). The X220t keyboard has no backlight, so
+the backlight detect function of this pin is unused.
+
+This patch hooks the PS/2 SET LED (0xED) data byte handler via its
+jump table entry at 0x6654. When the host sends the LED state byte,
+the trampoline checks bit 2 (Caps Lock) and configures GPIO163 as a
+push-pull output driven LOW (LED ON, active-low) or HIGH (LED OFF),
+then continues to the original handler.
+
+GPIO163 shares its pin with VCI_IN0# (VBAT wake input), but on the X230t
+this pin is used for keyboard backlight detection, which is unused with
+the X220t keyboard (no backlight). Switching from VCI_IN0# to GPIO mode
+has no practical side effect.
+
+Trampoline code is placed in free space at 0x24590.
+
+@@ capslock_led @@
+-00006650  20 20 c0 01 fc 66 00 00  98 67 00 00 98 67 00 00  |  ...f...g...g..|
++00006650  20 20 c0 01 0e 60 00 00  98 67 00 00 98 67 00 00  |  ...`....g..g..|
+-00024590  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
++00024590  0a 20 80 0f f0 00 cc c5  8a 21 09 00 51 26 80 90  |. .......!..Q&..|
+-000245A0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
++000245A0  cf 21 21 04 00 18 60 00  20 20 80 0f 00 00 fc 66  |.!!...`.  .....f|


### PR DESCRIPTION
Based on the patch from #281, I created patches for the rest of the xx30 series to restore the Caps Lock LED functionality. In my PR, this is also the default patch - it doesn’t change anything from the original behavior of the 7-row keyboard in the xx20, so I see no reason why it shouldn’t be the default. 